### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -13,8 +13,8 @@
 	<exclude-pattern>/node_modules/</exclude-pattern>
 
 	<!-- How to scan: include CLI args so you don't need to pass them manually -->
-	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
-	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- Usage instructions: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
+	<!-- Annotated ruleset: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
 	<arg value="sp"/>
 	<!-- Show sniff and progress -->
 	<arg name="basepath" value="./"/>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Inspired by the following projects and their contributors:
 * Default folder structure that mirrors WPGraphQL.
 * Helper classes, interfaces, methods, and traits to make it easier to register new GraphQL types.
 * Dependency management with [Composer](https://getcomposer.org/).
-* Code sniffing with [PHPCS](https://github.com/squizlabs/PHP_CodeSniffer), [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/), and [Automattic's WordPress VIP Coding Standards](https://github.com/Automattic/VIP-Coding-Standards)
+* Code sniffing with [PHPCS](https://github.com/PHPCSStandards/PHP_CodeSniffer), [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/), and [Automattic's WordPress VIP Coding Standards](https://github.com/Automattic/VIP-Coding-Standards)
 * Static Analysis with [PHPStan](https://phpstan.org/)
 * WPUnit Testing with [Codeception](http://codeception.com/) and [WPBrowser](https://wpbrowser.wptestkit.dev/).
 * [Docker](https://www.docker.com/) image generation.

--- a/wp-graphql-plugin-name/.phpcs.xml.dist
+++ b/wp-graphql-plugin-name/.phpcs.xml.dist
@@ -12,8 +12,8 @@
 	<exclude-pattern>/node_modules/</exclude-pattern>
 
 	<!-- How to scan: include CLI args so you don't need to pass them manually -->
-	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
-	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- Usage instructions: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
+	<!-- Annotated ruleset: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
 	<arg value="sp"/>
 	<!-- Show sniff and progress -->
 	<arg name="basepath" value="./"/>


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The \`squizlabs/PHP_CodeSniffer\` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932